### PR TITLE
add modules option support

### DIFF
--- a/lib/kmc.js
+++ b/lib/kmc.js
@@ -41,6 +41,10 @@ module.exports = Execution.extend({
             label: 'File charset',
             type: 'string',
             default: 'utf8'
+        },
+        modules: {
+            label: 'KISSY module config',
+            type: 'object'
         }
     },
     run: function (inputs, options, logger, settings) {
@@ -51,6 +55,7 @@ module.exports = Execution.extend({
         var inputs = this.inputs;
         var logger = this.logger;
         var packages = options.packages || {};
+        var modules = options.modules || {};
         var name = options.name;
         var src = path.resolve(options.src);
         var dest = path.resolve(options.dest);
@@ -79,7 +84,8 @@ module.exports = Execution.extend({
 
         var kmc = require('kmc');
         kmc.config({
-            packages: packages
+            packages: packages,
+            modules: modules
         });
 
         var records = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "task-kmc",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "lib/kmc.js",
   "description": "KISSY module compiler.",
   "homepage": "https://github.com/yuanyan/task-kmc",


### PR DESCRIPTION
support KMC modules config. It is same as KISSY.config('modules') which can be used to map module A to B(alias), then KMC when will compile B instead of A.
